### PR TITLE
add geoloc command integration updated on pull

### DIFF
--- a/desktop/js/gsl.js
+++ b/desktop/js/gsl.js
@@ -84,13 +84,28 @@ $('.eqLogicAttr[data-l1key=configuration][data-l2key=cmdgeoloc]').next().on('cli
         $('.eqLogicAttr[data-l2key=cmdgeoloc]').value(result.human);
     });
 });
+$(".cmdSendSel").on('click', function () {
+    var el = $(this);
+  jeedom.cmd.getSelectModal({cmd:{type:'info'}}, function(result) {
+       var calcul = el.closest('div').find('.eqLogicAttr[data-l1key=configuration][data-l2key=coordinated]');
+       calcul.val('');
+       calcul.atCaret('insert', result.human);
+     });
+});
 
 
 $('.eqLogicAttr[data-l1key=configuration][data-l2key=coordinatesType]').on('change', function (event) {
     if($('.eqLogicAttr[data-l1key=configuration][data-l2key=coordinatesType]').val() == 'jeedom'){
         $('.eqLogicAttr[data-l1key=configuration][data-l2key=coordinated]').closest('.form-group').hide();
+    }else if($('.eqLogicAttr[data-l1key=configuration][data-l2key=coordinatesType]').val() == 'cmd'){
+      	 $('.eqLogicAttr[data-l1key=configuration][data-l2key=coordinated]').closest('.form-group').show();
+      	$('.eqLogicAttr[data-l1key=configuration][data-l2key=coordinated]').css('width','92%');
+      	 $('.eqLogicAttr[data-l1key=configuration][data-l2key=coordinated]').closest('.form-group').find('.input-group-btn').show();
+      
     }else{
         $('.eqLogicAttr[data-l1key=configuration][data-l2key=coordinated]').closest('.form-group').show();
+      	$('.eqLogicAttr[data-l1key=configuration][data-l2key=coordinated]').css('width','100%');
+       $('.eqLogicAttr[data-l1key=configuration][data-l2key=coordinated]').closest('.form-group').find('.input-group-btn').hide();
     }
 });
 

--- a/desktop/php/gsl.php
+++ b/desktop/php/gsl.php
@@ -125,6 +125,7 @@ $eqLogics = eqLogic::byType($plugin->getId());
                                 <div class="col-sm-3">
                                     <select class="eqLogicAttr form-control" data-l1key="configuration" data-l2key="coordinatesType">
                                         <option value="">{{Fixe}}</option>
+                                        <option value="cmd">{{Commande Localisation}}</option>
                                         <option value="jeedom">{{Jeedom}}</option>
                                     </select>
                                 </div>
@@ -132,7 +133,10 @@ $eqLogics = eqLogic::byType($plugin->getId());
                             <div class="form-group">
                                 <label class="col-sm-3 control-label">{{Coordonnées}}<sup><i class="fas fa-question-circle tooltipstered" title="Latitude,longitude"></i></sup></label>
                                 <div class="col-sm-3">
-                                    <input class="eqLogicAttr form-control" data-l1key="configuration" data-l2key="coordinated"/>
+                                    <input class="eqLogicAttr form-control" data-l1key="configuration" data-l2key="coordinated" style="width: 92%;display: inline-block;"/>
+                                    <span class="input-group-btn" style="display:inline-block; width:auto"> 
+													<button type="button" class="btn btn-default cursor listCmdActionMessage tooltips cmdSendSel" title="{{Rechercher une commande}}" data-input="sendCmd"><i class="fas fa-list-alt"></i></button> 
+												</span> 
                                 </div>
                             </div>
                             <div class="form-group">


### PR DESCRIPTION
Salut Yoan, 

Une proposition pour intégrer une commande type info qui expose les longitudes et latitude au lieu de coordonnées fixes dans un équipement type "fix".
* Ajoute une option "commande" dans le select de type
* ajoute un bouton qui appelle la modale du core pour la selection du bouton
* modif du jquery pour l'affichage du bouton sur le select
* La mise à jour des coordonnées se fait sur le pull, après la mise à jour des partage de localisation google.
Mise à jour des distances après ces 2 là.

Je suis une quiche en css, il y a probablement moyen d'améliorer significativement l'affichage du bouton, là je réduit la taille de l'input text pour lui laisser la place, mais ce n'est pas aligner/propre.

@+
Ben