### PR TITLE
Ajout commande de precision pour les equipement de type "commande localisation"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ resources/node_modules/
 .idea
 jeedom_gsl.iml
 .vscode/sftp.json
+*cookies.txt

--- a/core/class/gsl.class.php
+++ b/core/class/gsl.class.php
@@ -361,7 +361,26 @@ class gsl extends eqLogic {
               }else{
                 $cmd->event($cmdLoc->execCmd());
               }
-              
+              // for precision commande
+              $cmdPrecName = $this->getConfiguration('coordinated_precision');
+              $cmd = $this->getCmd(null, 'accuracy');
+              if($cmdPrecName != null && trim($cmdPrecName) != ''){
+                  if (!is_object($cmd)) {
+                      $cmd = new cmd();
+                      $cmd->setName('precision');
+                      $cmd->setEqLogic_id($this->getId());
+                      $cmd->setLogicalId('accuracy');
+                      $cmd->setType('info');
+                      $cmd->setSubType('string');
+                      $cmd->save();
+                  }
+                  $cmdPrec = cmd::byId(str_replace('#','',$cmdPrecName));
+                  if(!is_object($cmdLoc)){
+                      log::add(__CLASS__, 'debug', 'cmd coordianted precision error : cmd not found');
+                  }else{
+                      $cmd->event($cmdPrec->execCmd());
+                  }
+              }  
             }else{
                 $cmd = $this->getCmd(null, 'coordinated');
                 $cmd->event($this->getConfiguration('coordinated'));
@@ -423,7 +442,7 @@ class gsl extends eqLogic {
             }
             $cmd = $this->getCmd(null, 'accuracy');
             if (!is_object($cmd)) {
-                $cmd = new gslContextualCmd();
+                $cmd = new cmd();
                 $cmd->setName('precision');
                 $cmd->setEqLogic_id($this->getId());
                 $cmd->setLogicalId('accuracy');
@@ -431,49 +450,6 @@ class gsl extends eqLogic {
                 $cmd->setSubType('string');
                 $cmd->save();
             }
-        }
-        // if is cmd and has precision
-        if($this->getConfiguration('type') == 'fix' && $this->getConfiguration('coordinatesType') == 'cmd'){
-            $cmdPrecName = $this->getConfiguration('coordinated_precision');
-            $cmd = $this->getCmd(null, 'accuracy');
-            if($cmdPrecName != null && trim($cmdPrecName) != ''){
-                if (!is_object($cmd)) {
-                    $cmd = new gslContextualCmd();
-                    $cmd->setName('precision');
-                    $cmd->setEqLogic_id($this->getId());
-                    $cmd->setLogicalId('accuracy');
-                    $cmd->setType('info');
-                    $cmd->setSubType('string');
-                    $cmd->save();
-                }
-
-                $cmdPrec = cmd::byId(str_replace('#','',$cmdPrecName));
-                if(!is_object($cmdLoc)){
-                	log::add(__CLASS__, 'debug', 'cmd coordianted precision error : cmd not found');
-                }else{
-                    $cmd->event($cmdPrec->execCmd());
-                }
-
-            } elseif (is_object($cmd)){
-                // $cmd->event('');
-                // $cmd = cmd::byEqLogicIdCmdName($this->getId(), 'precision');
-                log::add(__CLASS__, 'debug', 'post save cmd remove :'.$cmd->getId());
-                if (is_object($cmd))$cmd->remove();
-            }
-
-            
-            // if($this->getConfiguration('type') == 'fix' && $this->getConfiguration('coordinatesType') == 'cmd'){
-            //     $cmdPrecName = $this->getConfiguration('coordinated_precision');
-            // //     $cmd = $this->getCmd(null, 'accuracy');
-            //         $cmd = cmd::byEqLogicIdCmdName($this->getId(), 'precision');
-            //         if (is_object($cmd))$cmd->remove();
-            //     if(($cmdPrecName == null || trim($cmdPrecName) == '') && is_object($cmd)){
-            //         $cmd->remove();
-            //     }
-            // }
-
-
-            
         }
     }
    
@@ -739,42 +715,6 @@ class gsl extends eqLogic {
     /*     * **********************Getteur Setteur*************************** */
 }
 
-
-class gslContextualCmd extends cmd{
-    // class to auto delete if condition are not met in parent EqLogic
-    public function save($_direct = false){
-        log::add('gsl', 'debug', '--->> gslContextualCmd save called');
-        parent::save($_direct);
-    }
-    public function postSave(){
-        log::add('gsl', 'debug', 'gslContextualCmd postSave');
-        if($this->getLogicalId()=='accuracy'){
-            $eqLogic =  $this->getEqLogic();
-            if(!is_object($eqLogic)){
-                log::add('gsl', 'debug', 'Error Checking "accuracy" command, no logicalId found');
-                return;
-            }
-            log::add('gsl', 'debug', '----------------------- CMD TEST -------------------------');
-            log::add('gsl', 'debug', ' - eqlogic type :'.$eqLogic->getConfiguration('type'));
-            log::add('gsl', 'debug', ' - eqlogic coordinatesType :'.$eqLogic->getConfiguration('coordinatesType'));
-            log::add('gsl', 'debug', ' - eqlogic coordinated_precision :'.$eqLogic->getConfiguration('coordinated_precision'));
-
-
-            log::add('gsl', 'debug', '----------------------------------------------------------');
-            if($eqLogic->getConfiguration('type') == 'fix' && $eqLogic->getConfiguration('coordinatesType') == 'cmd'){
-                $cmdPrecName = $eqLogic->getConfiguration('coordinated_precision');
-                if($cmdPrecName == null || trim($cmdPrecName) == ''){
-                    log::add('gsl', 'debug', 'removing cmd : '.$this->getId());
-                   $this->remove();
-    
-                }
-            
-            }
-        }
-
-    }
-}
-
 class gslCmd extends cmd {
     /*     * *************************Attributs****************************** */
 
@@ -788,5 +728,25 @@ class gslCmd extends cmd {
         }
     }
 
+    // preUpdate check whether accuracy cmd is needed if not ->remove
+    public function preUpdate(){
+        if($this->getLogicalId()=='accuracy'){
+            $eqLogic =  $this->getEqLogic();
+            if(!is_object($eqLogic)){
+                log::add('gsl', 'debug', 'Error Checking "accuracy" command, no logicalId found');
+                return;
+            }
+            if($eqLogic->getConfiguration('type') == 'fix' && $eqLogic->getConfiguration('coordinatesType') == 'cmd'){
+                $cmdPrecName = $eqLogic->getConfiguration('coordinated_precision');
+                if($cmdPrecName == null || trim($cmdPrecName) == ''){
+                log::add('gsl', 'debug', 'removing cmd : '.$this->getId());
+                   $this->remove();
+                }
+            }else{
+                log::add('gsl', 'debug', 'removing cmd : '.$this->getId());
+                $this->remove();
+            }
+        }
+    }
     /*     * **********************Getteur Setteur*************************** */
 }

--- a/desktop/js/gsl.js
+++ b/desktop/js/gsl.js
@@ -77,6 +77,7 @@ function printEqLogic(_eqLogic) {
     $('.eqLogicAttr[data-l1key=configuration][data-l2key=precisionFiltre]').closest('.form-group').hide();
   }else{
     $('.eqLogicAttr[data-l1key=configuration][data-l2key=coordinated]').closest('.form-group').hide();
+    $('.eqLogicAttr[data-l1key=configuration][data-l2key=coordinated_precision]').closest('.form-group').hide();
     $('.form-control[data-l1key=configuration][data-l2key=coordinatesJeedom]').closest('.form-group').hide();
     $('.eqLogicAttr[data-l1key=configuration][data-l2key=isVisiblePanel]').closest('.form-group').show();
     $('.eqLogicAttr[data-l1key=configuration][data-l2key=coordinatesType]').closest('.form-group').hide();
@@ -91,7 +92,7 @@ $('.eqLogicAttr[data-l1key=configuration][data-l2key=cmdgeoloc]').next().on('cli
 $(".cmdSendSel").on('click', function () {
     var el = $(this);
   jeedom.cmd.getSelectModal({cmd:{type:'info'}}, function(result) {
-       var calcul = el.closest('div').find('.eqLogicAttr[data-l1key=configuration][data-l2key=coordinated]');
+       var calcul = el.closest('div').find('.eqLogicAttr[data-l1key=configuration]');
        calcul.val('');
        calcul.atCaret('insert', result.human);
      });
@@ -101,15 +102,22 @@ $(".cmdSendSel").on('click', function () {
 $('.eqLogicAttr[data-l1key=configuration][data-l2key=coordinatesType]').on('change', function (event) {
     if($('.eqLogicAttr[data-l1key=configuration][data-l2key=coordinatesType]').val() == 'jeedom'){
         $('.eqLogicAttr[data-l1key=configuration][data-l2key=coordinated]').closest('.form-group').hide();
+        $('.eqLogicAttr[data-l1key=configuration][data-l2key=coordinated_precision]').closest('.form-group').hide();
     }else if($('.eqLogicAttr[data-l1key=configuration][data-l2key=coordinatesType]').val() == 'cmd'){
-      	 $('.eqLogicAttr[data-l1key=configuration][data-l2key=coordinated]').closest('.form-group').show();
+        $('.eqLogicAttr[data-l1key=configuration][data-l2key=coordinated]').closest('.form-group').show();
+        $('.eqLogicAttr[data-l1key=configuration][data-l2key=coordinated_precision]').closest('.form-group').show();
+        $('.eqLogicAttr[data-l1key=configuration][data-l2key=coordinated_precision]').parent().addClass('input-group');
+        $('.eqLogicAttr[data-l1key=configuration][data-l2key=coordinated_precision]').closest('.form-group').find('.input-group-btn').show();
       	$('.eqLogicAttr[data-l1key=configuration][data-l2key=coordinated]').parent().addClass('input-group');
-      	 $('.eqLogicAttr[data-l1key=configuration][data-l2key=coordinated]').closest('.form-group').find('.input-group-btn').show();
-      
+        $('.eqLogicAttr[data-l1key=configuration][data-l2key=coordinated]').closest('.form-group').find('.input-group-btn').show();    
     }else{
         $('.eqLogicAttr[data-l1key=configuration][data-l2key=coordinated]').closest('.form-group').show();
       	$('.eqLogicAttr[data-l1key=configuration][data-l2key=coordinated]').parent().removeClass('input-group');
        $('.eqLogicAttr[data-l1key=configuration][data-l2key=coordinated]').closest('.form-group').find('.input-group-btn').hide();
+
+       $('.eqLogicAttr[data-l1key=configuration][data-l2key=coordinated_precision]').closest('.form-group').hide();
+      	$('.eqLogicAttr[data-l1key=configuration][data-l2key=coordinated_precision]').parent().removeClass('input-group');
+       $('.eqLogicAttr[data-l1key=configuration][data-l2key=coordinated_precision]').closest('.form-group').find('.input-group-btn').hide();
     }
 });
 

--- a/desktop/php/gsl.php
+++ b/desktop/php/gsl.php
@@ -148,9 +148,20 @@ $eqLogics = eqLogic::byType($plugin->getId());
                                 <label class="col-sm-3 control-label">{{Coordonnées}}<sup><i class="fas fa-question-circle tooltipstered" title="Latitude,longitude"></i></sup></label>
                                 <div class="col-sm-3">
                                     <div class="input-group">
-                                    	<input class="eqLogicAttr form-control" data-l1key="configuration" data-l2key="coordinated"/>
+                                    	<input id="coordinated" class="eqLogicAttr form-control" data-l1key="configuration" data-l2key="coordinated"/>
                                     	<span class="input-group-btn"> 
-													<a class="btn btn-default cursor listCmdActionMessage tooltips cmdSendSel" title="{{Rechercher une commande}}" data-input="sendCmd"><i class="fas fa-list-alt"></i></a> 
+                                            <a class="btn btn-default cursor listCmdActionMessage tooltips cmdSendSel" title="{{Rechercher une commande}}" data-input="#coordinated"><i class="fas fa-list-alt"></i></a> 
+										</span> 
+                                	</div>
+                                </div>
+                            </div>
+                            <div class="form-group">
+                                <label class="col-sm-3 control-label">{{Commande Précision}}<sup><i class="fas fa-question-circle tooltipstered" title="precision en mètre"></i></sup></label>
+                                <div class="col-sm-3">
+                                    <div class="input-group">
+                                    	<input id="coordinated_precision" class="eqLogicAttr form-control" data-l1key="configuration" data-l2key="coordinated_precision"/>
+                                    	<span class="input-group-btn"> 
+                                            <a class="btn btn-default cursor listCmdActionMessage tooltips cmdSendSel" title="{{Rechercher une commande}}" data-input="#coordinated_precision"><i class="fas fa-list-alt"></i></a> 
 										</span> 
                                 	</div>
                                 </div>


### PR DESCRIPTION
Salut Yoan,

Une proposition pour intégrer une commande type info qui expose la precision dans un équipement type "fix"/"commande de localisation". Ce qui permet d'avoir le cercle de precision sur la map si la source le fourni.

* ajout d'une configuration "coordinate_precision" avec la logique d'affichage
* commande accuracy créer et renseigné pour ce type d'équipement, 
* si conf "coordinate_precision " vide => commande accuracy supprimée. Logique gérée dans l'instance de gslCmd dans le preUpdate (pas moyen de le faire dans le postSave de l'eqLogic).

@+
Ben 